### PR TITLE
Allow overwriting the default Hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ $zk_log_dir     = '/mnt/zookeeper/log',
 $zk_install_dir = '/usr/share/zookeeper'
 ```
 
+## Hostname
+
+By default, the module will set `--hostname` of exhibitor to the node's FQDN. Unfortunately, machine's FQDN might be unresolvable in some cases, and thus it will prevent communication between nodes in the cluster. When that happens, you should see an error such as following in the exhibitor Web GUI
+
+```
+Hostname: ip-10-188-205-111.internal
+Server Id: 15
+Status: java.net.UnknownHostException: ip-10-188-205-111.internal
+```
+
+In such case, please consider using the instance's IP address to set as hostname rather than allow the module to use the FQDN by default. This can be done by updating your puppet code where you call the module, or use Hiera. An example of Hiera is shown below:
+
+```YAML
+exhibitor::defaultfile_opts:
+  hostname: "%{facts.networking.ip}"
+```
 
 ## Reference
 

--- a/templates/etc/init.d/exhibitor.erb
+++ b/templates/etc/init.d/exhibitor.erb
@@ -6,7 +6,13 @@ PID_FILE=/var/run/$NAME.pid
 
 [ -r /etc/default/exhibitor ] && . /etc/default/exhibitor
 
-HOSTNAME=$(hostname -f)
+HOSTNAME_IN_OPTS=$(echo ${EXHIBITOR_OPTS} | grep -oE '\-\-hostname "?[a-z0-9.-]+"?')
+
+if [ "${HOSTNAME_IN_OPTS}" != "" ]; then
+        HOSTNAME=$(echo ${HOSTNAME_IN_OPTS}| sed -E 's;--hostname ;;')
+else
+        HOSTNAME=$(hostname -f)
+fi
 
 DAEMON="java -jar ${EXHIBITOR_HOME}/exhibitor-standalone-<%= scope.lookupvar('::exhibitor::version') %>.jar"
 DAEMON_OPTS="--hostname ${HOSTNAME} ${EXHIBITOR_OPTS}"


### PR DESCRIPTION
Right now the module set up the option `--hostname` for Exhibitor using the node's FQDN, while the `defaultfile_opts` argument of the module provides a mechanism to set any options when we run Exhibitor.

There might be cases in which the FQDN is not resolvable between nodes (I ran into it while running nodes in AWS VPC). In such case, Exhibitor on will just print out the error `Status: java.net.UnknownHostException: xxxxxx`

I think, allowing users to overwrite the default `--hostname` options might be useful. In fact, I used this to get the exhibitor cluster work in my own VPC. 

Can you please consider this PR?

Thank you very much in advance